### PR TITLE
SQLIntegrityConstraintViolationException 발생시의 헨들링 생성

### DIFF
--- a/src/main/java/com/xylope/sogobot/domain/authorize/advice/AuthorizeAdvice.java
+++ b/src/main/java/com/xylope/sogobot/domain/authorize/advice/AuthorizeAdvice.java
@@ -1,15 +1,12 @@
 package com.xylope.sogobot.domain.authorize.advice;
 
-import com.xylope.sogobot.domain.authorize.exception.DomainNotFoundException;
-import com.xylope.sogobot.domain.discord.SogoBot;
-import com.xylope.sogobot.domain.discord.property.MessageProperties;
+import com.xylope.sogobot.domain.authorize.exception.AlreadyEnrolledException;
 import com.xylope.sogobot.infra.exception.EmailSendingFailureException;
 import com.xylope.sogobot.infra.service.MailSenderService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.EmbedBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -17,17 +14,14 @@ import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
 import javax.mail.MessagingException;
-import java.awt.*;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Arrays;
-import java.util.Objects;
 
-@ControllerAdvice @Slf4j
+@ControllerAdvice ("com.xylope.sogobot.domain.authorize")@Slf4j
 @RequiredArgsConstructor
 public class AuthorizeAdvice {
-    private final SogoBot sogoBot;
     private final MailSenderService mailSenderService;
     private final SpringTemplateEngine templateEngine;
-    private final MessageProperties messageProperties;
 
     @Value("${bot.admin-email")
     private String adminEmail;
@@ -42,8 +36,13 @@ public class AuthorizeAdvice {
         return "error/wrong-token";
     }
 
+    @ExceptionHandler(AlreadyEnrolledException.class)
+    public String alreadyEnrolledException() {
+        return "/error/already-enrolled";
+    }
+
     @ExceptionHandler(Exception.class)
-    public void unexpectedExceptionOccurred(Exception e) {
+    public void handleUnexpectedException(Exception e) {
         log.warn("예상치못한 예외가 발생하였습니다!\n" + e.getLocalizedMessage());
 
         Context context = new Context();

--- a/src/main/java/com/xylope/sogobot/domain/authorize/controller/AuthorizeController.java
+++ b/src/main/java/com/xylope/sogobot/domain/authorize/controller/AuthorizeController.java
@@ -3,33 +3,21 @@ package com.xylope.sogobot.domain.authorize.controller;
 import com.xylope.sogobot.domain.authorize.exception.AlreadyEnrolledException;
 import com.xylope.sogobot.domain.authorize.service.UserAuthorizeService;
 import com.xylope.sogobot.domain.authorize.util.AuthorizeTokenUtil;
-import com.xylope.sogobot.domain.discord.SogoBot;
-import com.xylope.sogobot.domain.discord.manager.DiscordRoleManager;
 import com.xylope.sogobot.domain.enroll.service.EnrollService;
 import com.xylope.sogobot.global.dto.AuthorizedUserDto;
-import com.xylope.sogobot.global.dto.UnauthorizedUserInfoDto;
-import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.TextChannel;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.awt.*;
-import java.util.Objects;
-
 @Controller @RequiredArgsConstructor
 public class AuthorizeController {
     private final AuthorizeTokenUtil authorizeTokenUtil;
-    private final UserAuthorizeService userAuthorizeService;
     private final EnrollService enrollService;
 
     @RequestMapping("/authorize")
     public String authorize(@RequestParam String token) {
         AuthorizedUserDto user = authorizeTokenUtil.getUserByToken(token);
-
         enrollService.enrollUser(user);
         return "authorize";
     }

--- a/src/main/java/com/xylope/sogobot/domain/authorize/exception/AlreadyEnrolledException.java
+++ b/src/main/java/com/xylope/sogobot/domain/authorize/exception/AlreadyEnrolledException.java
@@ -1,10 +1,13 @@
 package com.xylope.sogobot.domain.authorize.exception;
 
 import com.xylope.sogobot.global.dto.UnauthorizedUserInfoDto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@RequiredArgsConstructor @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class AlreadyEnrolledException extends RuntimeException {
-    private final UnauthorizedUserInfoDto info;
+    private UnauthorizedUserInfoDto info;
 }

--- a/src/main/java/com/xylope/sogobot/domain/enroll/service/EnrollService.java
+++ b/src/main/java/com/xylope/sogobot/domain/enroll/service/EnrollService.java
@@ -1,10 +1,13 @@
 package com.xylope.sogobot.domain.enroll.service;
 
+import com.xylope.sogobot.domain.authorize.exception.AlreadyEnrolledException;
 import com.xylope.sogobot.domain.discord.manager.DiscordRoleManager;
 import com.xylope.sogobot.domain.enroll.repository.UserRepository;
 import com.xylope.sogobot.global.dto.AuthorizedUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.sql.SQLIntegrityConstraintViolationException;
 
 @Service @RequiredArgsConstructor
 public class EnrollService {
@@ -12,6 +15,7 @@ public class EnrollService {
 
     public void enrollUser(AuthorizedUserDto user) {
         DiscordRoleManager.addDepartmentRole(user.getDepartmentType(), user.getId());
+        if(userRepository.existsById(user.getId())) throw new AlreadyEnrolledException();
         userRepository.save(user.toEntity());
     }
 }

--- a/src/main/resources/templates/error/already-enrolled.html
+++ b/src/main/resources/templates/error/already-enrolled.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>이런!</title>
+</head>
+<body>
+<h1>이미 인증하셧어요!</h1>
+<i><span style="text-decoration: line-through; color: gray">어떻게서든 오류를 찾으려는 당신... 리스펙트합니다</span></i>
+</body>
+</html>


### PR DESCRIPTION
해결한 에러
```
A 가 인증을 시도함 (인증ID = 20210902A1518)
A 가 인증을 시도함 (인증ID = 20210902A1519)
A가 20210902A1518 에대한 인증을 끝마침
A가 20210902A1519 에대한 인증링크로 들어갈시, 같은 discord id 를 가진 또하나의 인증내역이 추가되므로, 

SQLIntegrityConstraintViolationException 발생
```

해결방법
```
repository.save 로 등록하기전 같은 id 의 튜플이 존재하는지 검사하여 존재할경우 
ALreadyEnrolledException throw 후 Advice 단에서 처리```